### PR TITLE
Bearer format in security scheme is optional

### DIFF
--- a/src/v3/schema.rs
+++ b/src/v3/schema.rs
@@ -910,7 +910,7 @@ pub enum SecurityScheme {
     Http {
         scheme: String,
         #[serde(rename = "bearerFormat")]
-        bearer_format: String,
+        bearer_format: Option<String>,
     },
     #[serde(rename = "oauth2")]
     OAuth2 { flows: Box<Flows> },


### PR DESCRIPTION
They are just hints according to the spec: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#security-scheme-object

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>