### PR TITLE
Make Parameter::style public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apple-bloom"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["softprops <d.tangren@gmail.com>", "Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>"]
 description = "Rust bindings for openapi schemas"
 homepage = "https://github.com/hbina/apple-bloom"

--- a/src/v3/schema.rs
+++ b/src/v3/schema.rs
@@ -407,12 +407,12 @@ pub struct Parameter {
     /// value. Default values (based on value of in): for `query` - `form`; for `path` - `simple`; for
     /// `header` - `simple`; for cookie - `form`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    style: Option<ParameterStyle>,
+    pub style: Option<ParameterStyle>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-enum ParameterStyle {
+pub enum ParameterStyle {
     Matrix,
     Label,
     Form,


### PR DESCRIPTION
Currently, instantiating a Parameter is not possible, because it has neither a constructor, nor are its fields public.

Since the field currently also cannot be read/set from outside the crate, make it public.

Also bump version